### PR TITLE
fix: 自己参照URLによる無限ループを防止

### DIFF
--- a/custom-card-link.php
+++ b/custom-card-link.php
@@ -108,7 +108,12 @@ function normalizeUrlForComparison($url) {
 	}
 
 	$host = strtolower($parts['host']);
-	$port = isset($parts['port']) ? ':'.$parts['port'] : '';
+	$scheme = strtolower($parts['scheme'] ?? '');
+	$port = $parts['port'] ?? null;
+	if(($scheme === 'http' && $port === 80) || ($scheme === 'https' && $port === 443)) {
+		$port = null;
+	}
+	$port = isset($port) ? ':'.$port : '';
 	$path = $parts['path'] ?? '/';
 	$path = '/'.ltrim($path, '/');
 	$path = untrailingslashit($path);

--- a/custom-card-link.php
+++ b/custom-card-link.php
@@ -93,22 +93,78 @@ add_action('admin_enqueue_scripts', function($hook_suffix) {
 });
 
 /**
-* サーバ側処理
-*/
+ * URLを比較用に正規化する
+ *
+ * クエリ文字列とフラグメントはページの識別に使用せず、
+ * 末尾のスラッシュの有無も同一URLとして扱う。
+ *
+ * @param string $url
+ * @return string
+ */
+function normalizeUrlForComparison($url) {
+	$parts = wp_parse_url(trim($url));
+	if(!is_array($parts) || empty($parts['host'])) {
+		return '';
+	}
+
+	$host = strtolower($parts['host']);
+	$port = isset($parts['port']) ? ':'.$parts['port'] : '';
+	$path = $parts['path'] ?? '/';
+	$path = '/'.ltrim($path, '/');
+	$path = untrailingslashit($path);
+
+	return $host.$port.$path;
+}
+
+/**
+ * 指定されたURLが現在表示中のURLか判定する
+ *
+ * @param string $url
+ * @return bool
+ */
+function isCurrentRequestUrl($url) {
+	if(empty($_SERVER['HTTP_HOST']) || empty($_SERVER['REQUEST_URI'])) {
+		return false;
+	}
+
+	$scheme      = is_ssl() ? 'https://' : 'http://';
+	$host        = sanitize_text_field(wp_unslash($_SERVER['HTTP_HOST']));
+	$request_uri = wp_unslash($_SERVER['REQUEST_URI']);
+	$current_url = $scheme.$host.$request_uri;
+
+	return normalizeUrlForComparison($url) === normalizeUrlForComparison($current_url);
+}
+
+/**
+ * サーバ側処理
+ */
 add_action('init', function() {
 	register_block_type_from_metadata(__DIR__ . '/build',
 		array(
 			'render_callback' => function($attributes) {
 				//入力チェック
-				$url     = $attributes['url'] ?? '';
-				$ogps    = \Ccl_Plugin\library\Get_OGP_InWP::get(trim($url));
+				$url = trim($attributes['url'] ?? '');
+				if($url == '') {
+					if(!is_singular()) {
+						return __('Please enter the URL.', 'ccl-plugin');
+					}
+					return;
+				}
+
 				$post_id = url_to_postid($url);
-				if($url == '' && !is_singular()) {
-					return __('Please enter the URL.', 'ccl-plugin');
-				} else if(($ogps == [] && $post_id == 0) && !is_singular()){
+				if($post_id == 0 && isCurrentRequestUrl($url)) {
+					return;
+				}
+
+				// 内部リンクはWordPressの投稿データを使用するため、HTTPリクエストは不要
+				$ogps = $post_id == 0
+					? \Ccl_Plugin\library\Get_OGP_InWP::get($url)
+					: [];
+
+				if(($ogps == [] && $post_id == 0) && !is_singular()){
 					return __('Please enter a valid URL.', 'ccl-plugin');
 				}
-				if($url == '' || ($ogps == [] && $post_id == 0)){
+				if($ogps == [] && $post_id == 0){
 					return;
 				}
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "lint:js": "wp-scripts lint-js",
     "lint--fix:js": "wp-scripts lint-js --fix",
     "packages-update": "wp-scripts packages-update",
-    "plugin-zip": "wp-scripts plugin-zip"
+    "plugin-zip": "wp-scripts plugin-zip",
+    "wp-env:start": "wp-env start",
+    "wp-env:stop": "wp-env stop",
+    "wp-env:clean": "wp-env clean all",
+    "wp-env:logs": "wp-env logs --no-watch"
   },
   "devDependencies": {
     "@wordpress/env": "^10.20.0",


### PR DESCRIPTION
## 概要

カードのリンク先に表示中のページ自身のURLを指定した場合に、サーバー内部で再帰的なHTTPリクエストが発生する問題を修正します。

## 原因

動的ブロックの描画時、内部リンクかどうかを判定する前にOGP取得用の `wp_remote_get()` を実行していました。自己URLの場合は、取得先ページでも同じブロックが描画され、再び同じURLを取得する処理が繰り返されていました。

## 変更内容

- 空URLの検証をHTTP取得より先に実行
- `url_to_postid()` による内部投稿判定をOGP取得より先に実行
- 内部投稿URLでは不要なHTTP取得を行わないよう変更
- 現在のリクエストURLとリンク先URLを正規化して比較し、自己参照時は描画処理を終了
- URL比較ではクエリ文字列、フラグメント、末尾スラッシュの差を無視

## 影響

自己参照URLによるCPU・帯域使用量の増加を防止します。内部投稿カードは従来どおりWordPressの投稿データを使用し、外部URLのみOGP取得を行います。

## 確認内容

- PHP構文チェック
- `git diff --check`
- 自己URL: HTTP取得0回
- 内部投稿URL: HTTP取得0回
- 外部URL: HTTP取得1回

Closes #19
