### PR TITLE
外部OGP取得結果をキャッシュして初期表示を改善

### DIFF
--- a/custom-card-link.php
+++ b/custom-card-link.php
@@ -20,11 +20,13 @@ const MAX_DESCRIPTION_CHAR_OF_NUM = 200; //setting-pc.jsおよびsetting-sp.js�
 
 require_once __DIR__ .'/classes/CustomCardLink.php';
 require_once __DIR__ .'/library/Get_OGP_InWP/get_ogp_inwp.php';
+require_once __DIR__ .'/functions/ogp_cache.php';
 require_once __DIR__ .'/functions/rest_api.php';
 require_once __DIR__ .'/functions/style.php';
 require_once __DIR__ .'/functions/data.php';
 
 use function Ccl_Plugin\functions\data\get_setting;
+use function Ccl_Plugin\functions\ogp_cache\get_cached_ogp;
 
 /**
  * 翻訳ファイルの読み込み
@@ -163,7 +165,7 @@ add_action('init', function() {
 
 				// 内部リンクはWordPressの投稿データを使用するため、HTTPリクエストは不要
 				$ogps = $post_id == 0
-					? \Ccl_Plugin\library\Get_OGP_InWP::get($url)
+					? get_cached_ogp($url)
 					: [];
 
 				if(($ogps == [] && $post_id == 0) && !is_singular()){

--- a/functions/ogp_cache.php
+++ b/functions/ogp_cache.php
@@ -1,0 +1,123 @@
+<?php
+namespace Ccl_Plugin\functions\ogp_cache;
+
+use Ccl_Plugin\library\Get_OGP_InWP;
+
+/**
+ * OGPキャッシュのキー生成用にURLを正規化する
+ *
+ * フラグメントはHTTPリクエストに送信されないため除外する。
+ * 一方、スキームとクエリ文字列は取得結果に影響する可能性があるため維持する。
+ *
+ * @param string $url
+ * @return string
+ */
+function normalize_url_for_cache($url) {
+	$url   = trim($url);
+	$parts = wp_parse_url($url);
+
+	if(!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+		return preg_replace('/#.*$/', '', $url);
+	}
+
+	$scheme = strtolower($parts['scheme']);
+	$host   = strtolower($parts['host']);
+	$port   = $parts['port'] ?? null;
+	if(($scheme === 'http' && $port === 80) || ($scheme === 'https' && $port === 443)) {
+		$port = null;
+	}
+
+	$user_info = '';
+	if(isset($parts['user'])) {
+		$user_info = $parts['user'];
+		if(isset($parts['pass'])) {
+			$user_info .= ':'.$parts['pass'];
+		}
+		$user_info .= '@';
+	}
+
+	$port  = isset($port) ? ':'.$port : '';
+	$path  = empty($parts['path']) ? '/' : $parts['path'];
+	$query = isset($parts['query']) ? '?'.$parts['query'] : '';
+
+	return $scheme.'://'.$user_info.$host.$port.$path.$query;
+}
+
+/**
+ * OGPキャッシュのキーを取得する
+ *
+ * @param string $url
+ * @return string
+ */
+function get_cache_key($url) {
+	return 'ccl_ogp_v1_'.hash('sha256', normalize_url_for_cache($url));
+}
+
+/**
+ * キャッシュを考慮して外部URLのOGP情報を取得する
+ *
+ * 同一リクエスト内では静的変数の値を再利用し、リクエストをまたぐ場合は
+ * WordPress Transientに保存した値を再利用する。
+ *
+ * @param string $url
+ * @return array
+ */
+function get_cached_ogp($url) {
+	static $request_cache = [];
+
+	$cache_key = get_cache_key($url);
+	if(array_key_exists($cache_key, $request_cache)) {
+		return $request_cache[$cache_key];
+	}
+
+	$cached = get_transient($cache_key);
+	if(
+		is_array($cached)
+		&& ($cached['version'] ?? null) === 1
+		&& isset($cached['data'])
+		&& is_array($cached['data'])
+	) {
+		$request_cache[$cache_key] = $cached['data'];
+		return $request_cache[$cache_key];
+	}
+
+	$ogps = Get_OGP_InWP::get($url);
+	if(!is_array($ogps)) {
+		$ogps = [];
+	}
+
+	$request_cache[$cache_key] = $ogps;
+
+	$default_expiration = empty($ogps)
+		? 5 * MINUTE_IN_SECONDS
+		: DAY_IN_SECONDS;
+
+	/**
+	 * OGP情報をキャッシュする期間を変更する
+	 *
+	 * 0以下を返すとTransientへの保存を無効化する。
+	 *
+	 * @param int    $default_expiration キャッシュ期間（秒）
+	 * @param string $url                取得対象のURL
+	 * @param array  $ogps               取得したOGP情報
+	 */
+	$expiration = (int) apply_filters(
+		'ccl_ogp_cache_expiration',
+		$default_expiration,
+		$url,
+		$ogps
+	);
+
+	if($expiration > 0) {
+		set_transient(
+			$cache_key,
+			array(
+				'version' => 1,
+				'data'    => $ogps,
+			),
+			$expiration
+		);
+	}
+
+	return $request_cache[$cache_key];
+}


### PR DESCRIPTION
## 概要

外部URLを指定したカードを複数配置したとき、カードごとに同期HTTP通信が発生していた問題を改善します。

Closes #14

## 原因

動的ブロックの `render_callback` から、外部カードごとに `Get_OGP_InWP::get()` を直接呼び出していました。同一URLでも取得結果が再利用されず、外部サイトの応答時間がカード数に応じて積み上がっていました。

## 変更内容

- 同一リクエスト内でURL単位のOGP取得結果を再利用
- WordPress Transientでリクエストをまたいで取得結果を再利用
  - 正常取得: 24時間
  - 取得失敗: 5分
- URLを正規化し、SHA-256ハッシュから固定長のキャッシュキーを生成
- `ccl_ogp_cache_expiration` フィルターでキャッシュ期間を変更可能に設定
- 外部OGPライブラリは変更せず、呼び出し側にキャッシュ層を追加

## 影響

- 同一ページ内の同一URLへの外部HTTP通信は1回になります
- キャッシュ済みURLは次回以降の表示で外部HTTP通信を行いません
- 内部リンク、自己参照URL、既存のブロック属性には変更ありません

## 確認内容

- [x] wp-envで同一URLのカード2枚を描画し、コールド時のHTTP取得が1回であることを確認
- [x] 次のリクエストではHTTP取得0回でカードが描画されることを確認
- [x] 取得失敗が5分間キャッシュされることを確認
- [x] 正常取得が24時間キャッシュされることを確認
- [x] PHP構文チェック
- [x] `yarn lint:css`
- [x] `yarn build`
- [x] `git diff --check`

## 補足

`yarn lint` 全体は、今回変更していない `src/admin.js:14` の既存依存 `@wordpress/api` を解決できず失敗します。今回のPHP変更とは無関係です。