### PR TITLE
[via Codex] バージョン入力による手動リリースフローへ変更

### DIFF
--- a/.github/workflows/commit_svn.yml
+++ b/.github/workflows/commit_svn.yml
@@ -1,59 +1,243 @@
 name: Deploy WordPress Plugin
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "リリースバージョン（先頭vなしのX.Y.Z）"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wordpress-release-v${{ inputs.version }}
+  cancel-in-progress: false
 
 jobs:
-  tag:
-    name: New tag
+  release:
+    name: Release v${{ inputs.version }}
     runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_TAG: v${{ inputs.version }}
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Validate versions
+      - name: Validate release request
         run: |
-          tag_version="${GITHUB_REF_NAME#v}"
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error title=Invalid release branch::リリースはmainブランチからのみ実行できます (ref=${GITHUB_REF})"
+            exit 1
+          fi
+
+          # WordPress.orgのSVNタグは数字とピリオドのみを使用するため、安定版X.Y.Zだけを許可する。
+          semver_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          if [[ ! "${RELEASE_VERSION}" =~ ${semver_pattern} ]]; then
+            echo "::error title=Invalid version::バージョンはプレリリース表記や先頭vを含まないX.Y.Z形式にしてください (version=${RELEASE_VERSION})"
+            exit 1
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Check existing Git tag
+        id: existing-tag
+        run: |
+          remote_tag="$(
+            git ls-remote --tags --refs origin "refs/tags/${RELEASE_TAG}" |
+              awk 'NR == 1 { print $1 }'
+          )"
+
+          if [[ -z "${remote_tag}" ]]; then
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+            echo "${RELEASE_TAG} does not exist yet."
+            exit 0
+          fi
+
+          git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          main_commit="$(git rev-parse HEAD)"
+
+          if [[ "${tag_commit}" != "${main_commit}" ]]; then
+            echo "::error title=Git tag conflict::${RELEASE_TAG}は現在のmainとは別のコミットを指しています (tag=${tag_commit}, main=${main_commit})。既存タグは変更しません"
+            exit 1
+          fi
+
+          echo "exists=true" >> "${GITHUB_OUTPUT}"
+          echo "${RELEASE_TAG} already points to ${main_commit}."
+
+      - name: Setup Volta
+        uses: volta-cli/action@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.0"
+          coverage: none
+
+      - name: Update source versions
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const version = process.env.RELEASE_VERSION;
+          const packagePath = "package.json";
+          const pluginPath = "custom-card-link.php";
+
+          const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+          packageJson.version = version;
+          fs.writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+          const pluginSource = fs.readFileSync(pluginPath, "utf8");
+          const versionHeader = /^([ \t]*\*?[ \t]*Version:[ \t]*).*$/gm;
+          const matches = [...pluginSource.matchAll(versionHeader)];
+
+          if (matches.length !== 1) {
+            throw new Error(
+              `${pluginPath}のVersionヘッダーを一意に特定できませんでした (count=${matches.length})`,
+            );
+          }
+
+          fs.writeFileSync(
+            pluginPath,
+            pluginSource.replace(
+              versionHeader,
+              (header, prefix) => `${prefix}${version}`,
+            ),
+          );
+          NODE
+
           package_version="$(node -p "require('./package.json').version")"
           plugin_version="$(
-            awk '/^[[:space:]]*Version:[[:space:]]*/ {
-              sub(/^[[:space:]]*Version:[[:space:]]*/, "")
+            awk '/^[[:space:]]*\*?[[:space:]]*Version:[[:space:]]*/ {
+              sub(/^[[:space:]]*\*?[[:space:]]*Version:[[:space:]]*/, "")
               sub(/\r$/, "")
               print
               exit
             }' custom-card-link.php
           )"
 
-          if [[ -z "${tag_version}" || -z "${package_version}" || -z "${plugin_version}" ]]; then
-            echo "::error title=Version validation failed::バージョンを取得できませんでした (tag=${tag_version}, package.json=${package_version}, custom-card-link.php=${plugin_version})"
+          if [[ "${package_version}" != "${RELEASE_VERSION}" || "${plugin_version}" != "${RELEASE_VERSION}" ]]; then
+            echo "::error title=Version update failed::バージョン更新に失敗しました (input=${RELEASE_VERSION}, package.json=${package_version}, custom-card-link.php=${plugin_version})"
             exit 1
           fi
 
-          if [[ "${tag_version}" != "${package_version}" || "${tag_version}" != "${plugin_version}" ]]; then
-            echo "::error title=Version mismatch::バージョンが一致しません (tag=${tag_version}, package.json=${package_version}, custom-card-link.php=${plugin_version})"
-            exit 1
-          fi
-
-          echo "Version ${tag_version} is valid."
-
-      - name: Setup Volta
-        uses: volta-cli/action@v5
-      
-      - name: Build
+      - name: Install dependencies
         run: |
-          yarn
-          yarn build
-      
+          yarn install --immutable
+          composer install --no-interaction --no-progress
+
+      - name: Run lint and tests
+        run: |
+          yarn lint
+          composer check:php
+
+      - name: Build
+        run: yarn build
+
+      - name: Prepare release commit
+        id: release-commit
+        env:
+          TAG_EXISTS: ${{ steps.existing-tag.outputs.exists }}
+        run: |
+          unexpected_changes="$(
+            git diff --name-only |
+              grep -Ev '^(package\.json|custom-card-link\.php|build/)' || true
+          )"
+          if [[ -n "${unexpected_changes}" ]]; then
+            echo "::error title=Unexpected changes::リリース処理で想定外のファイルが変更されました"
+            echo "${unexpected_changes}"
+            exit 1
+          fi
+
+          if [[ "${TAG_EXISTS}" == "true" ]]; then
+            if ! git diff --quiet -- package.json custom-card-link.php; then
+              echo "::error title=Existing tag is immutable::既存タグ${RELEASE_TAG}のソースバージョンと入力値が一致しません"
+              exit 1
+            fi
+
+            # 再実行時は既存タグを変更せず、buildの生成差分だけを破棄する。
+            git restore --source=HEAD --staged --worktree -- build
+            if [[ -n "$(git status --porcelain -- build)" ]]; then
+              echo "::error title=Unexpected build files::既存タグに含まれないbuild生成物が作成されました"
+              git status --short -- build
+              exit 1
+            fi
+            release_sha="$(git rev-parse HEAD)"
+            echo "Reusing existing release commit ${release_sha}."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add package.json custom-card-link.php build
+
+            if git diff --cached --quiet; then
+              echo "Source versions and build files are already up to date."
+            else
+              git commit -m "[via Codex] chore: release ${RELEASE_VERSION}"
+            fi
+
+            release_sha="$(git rev-parse HEAD)"
+            git push origin "HEAD:refs/heads/main"
+            echo "Pushed release commit ${release_sha} to main."
+          fi
+
+          echo "release_sha=${release_sha}" >> "${GITHUB_OUTPUT}"
+          echo "RELEASE_SHA=${release_sha}" >> "${GITHUB_ENV}"
+
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SLUG: custom-card-link
+          # workflow_dispatchではGITHUB_REFがmainになるため、入力値をSVNタグ名として明示する。
+          VERSION: ${{ inputs.version }}
 
-      - name: Create GitHub Release
+      - name: Create or verify Git tag
+        run: |
+          remote_tag="$(
+            git ls-remote --tags --refs origin "refs/tags/${RELEASE_TAG}" |
+              awk 'NR == 1 { print $1 }'
+          )"
+
+          if [[ -n "${remote_tag}" ]]; then
+            git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+            tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+
+            if [[ "${tag_commit}" != "${RELEASE_SHA}" ]]; then
+              echo "::error title=Git tag conflict::${RELEASE_TAG}は別のコミットを指しています (tag=${tag_commit}, release=${RELEASE_SHA})。既存タグは変更しません"
+              exit 1
+            fi
+
+            echo "${RELEASE_TAG} already points to ${RELEASE_SHA}; skipping tag creation."
+          else
+            git tag "${RELEASE_TAG}" "${RELEASE_SHA}"
+            git push origin "refs/tags/${RELEASE_TAG}"
+            echo "Created ${RELEASE_TAG} at ${RELEASE_SHA}."
+          fi
+
+      - name: Create GitHub Release if needed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes "Release ${{ github.ref_name }}"
+          release_lookup_error="${RUNNER_TEMP}/release-lookup-error.log"
+
+          if gh api --silent \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+            2> "${release_lookup_error}"; then
+            echo "GitHub Release ${RELEASE_TAG} already exists; skipping creation."
+          elif grep -q "HTTP 404" "${release_lookup_error}"; then
+            gh release create "${RELEASE_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --verify-tag \
+              --target "${RELEASE_SHA}" \
+              --title "${RELEASE_TAG}" \
+              --notes "Release ${RELEASE_TAG}"
+          else
+            echo "::error title=GitHub Release lookup failed::GitHub Release ${RELEASE_TAG}の状態を確認できませんでした"
+            sed -n '1,20p' "${release_lookup_error}"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ $ composer check:php
 `composer check:php`では、PHPの構文チェックとWordPress向けPHPStanによる静的解析を実行する。
 
 ## Deploy（SVNへのコミット）
-`vX.X.X`形式でタグを作成すると、GitHub Actionのワークフローが実行され、SVNに自動でデプロイされる。
+1. GitHub Actionsの「Deploy WordPress Plugin」で`main`を選択し、「Run workflow」を開く。
+2. リリースするバージョンを先頭`v`なしの`X.Y.Z`形式で入力して実行する。
+
+ワークフローは`package.json`と`custom-card-link.php`のバージョン更新、lint・テスト・build、リリースコミットの`main`へのpush、WordPress.orgへのデプロイを順に行う。デプロイ成功後に`vX.Y.Z`タグとGitHub Releaseを作成する。
+再実行時は同じコミットを指す既存タグと既存GitHub Releaseを再利用する。タグが別のコミットを指す場合は、タグを変更せずエラー終了する。
 
 ## Third-party resources
 ### Get_OGP_InWP


### PR DESCRIPTION
[via Codex]

## 概要

Gitタグpush起点のデプロイを廃止し、GitHub Actionsの「Run workflow」で `X.Y.Z` を入力して開始するリリースフローへ変更します。

入力値を正として `package.json` と `custom-card-link.php` を更新し、依存関係のインストール、lint・PHPチェック・build、リリースコミットの `main` へのpush、WordPress.orgへのデプロイを順に実行します。WordPress.orgへのデプロイが成功した後にだけ `vX.Y.Z` のGitタグとGitHub Releaseを作成します。

## 変更内容

- トリガーを入力必須の `workflow_dispatch` のみに変更
- `main` 以外からの実行と、先頭 `v`・プレリリース・先頭ゼロを含む値を変更操作前に拒否
- 入力した `X.Y.Z` で `package.json` とPHPプラグインヘッダーを自動更新
- Yarn・Composer依存関係の固定インストール後、JS/CSS lint、PHP構文チェック・PHPStan、buildを実行
- バージョンとbuild生成物をリリースコミットとして `main` へpush
- `VERSION=X.Y.Z` を明示してWordPress.orgへデプロイし、成功後に `vX.Y.Z` タグを作成
- 同一バージョンを直列化する `concurrency` と `contents: write` を明示
- 既存Gitタグが現在の `main` と同じコミットなら再利用し、別コミットなら削除・上書きせず終了
- 既存GitHub Releaseはスキップし、404の場合だけ作成
- READMEに手動リリース手順と再実行時の挙動を追記

## WordPress.orgデプロイActionを手動起点で利用できる根拠

10up Actionの `stable`（確認時: `54bd289b8525fd23a5c365ec369185f2966529c2`）は、`VERSION` が指定されていれば `GITHUB_REF` ではなくその値を利用します（[`deploy.sh` 59-64行](https://github.com/10up/action-wordpress-plugin-deploy/blob/54bd289b8525fd23a5c365ec369185f2966529c2/deploy.sh#L59-L64)）。また、デプロイ対象は `GITHUB_WORKSPACE` の変更をローカルコミットしたうえで `git archive HEAD` から作成されます（[`deploy.sh` 128-165行](https://github.com/10up/action-wordpress-plugin-deploy/blob/54bd289b8525fd23a5c365ec369185f2966529c2/deploy.sh#L128-L165)）。そのため、`workflow_dispatch` でも入力値を `VERSION` に渡し、作成済みのローカルリリースコミットを `HEAD` にして実行すれば、正しいSVNタグ名と内容でデプロイできます。

同じSVNタグが存在する場合はAction自身が早期成功終了します（[`deploy.sh` 109-116行](https://github.com/10up/action-wordpress-plugin-deploy/blob/54bd289b8525fd23a5c365ec369185f2966529c2/deploy.sh#L109-L116)）。したがって、デプロイ成功後にGitタグ作成だけが失敗したケースも、再実行時に既存SVNタグを再利用してタグ作成から安全に復旧できます。

プレリリースを許可しない理由は、WordPress.org公式がSVNタグを数字とピリオドのみとするよう案内しているためです（[Plugin Developer FAQ](https://developer.wordpress.org/plugins/wordpress-org/plugin-developer-faq/#how-should-i-name-my-tags-a-k-a-releases)）。

## 検証結果

- `actionlint`: 成功
- ワークフロー内の全Bashスクリプトに対する `bash -n`: 成功
- `git diff --check`: 成功
- `yarn install --immutable`: 成功
- Composer lock検証・依存関係インストール: 成功
- `yarn lint`: 成功
- PHP 8.0での全18ファイル構文チェック: 成功
- PHPStan: 成功
- `yarn build`: 成功
- 分岐シミュレーション:
  - 正しい `X.Y.Z` / 不正形式 / `main` 以外
  - Gitタグなし
  - 同一コミットを指す既存タグ
  - 別コミットを指す既存タグ
  - デプロイ前にタグが未作成であること
  - デプロイ成功後のタグ作成
  - 既存GitHub Releaseあり / なし

`v1.1.1` はGitタグと `main` が同じコミットを指し、GitHub ReleaseとWordPress.org SVNタグが存在することを読み取り確認しました。

## 意図的に実行していない外部操作

PR検証では、実際のワークフロー実行、Actionからの `main` push、WordPress.orgへのデプロイ、Gitタグ作成、GitHub Release作成は行っていません。既存の `v1.1.1` の削除・再作成・再デプロイも行っていません。