### PR TITLE
CSSをカード描画時のみ読み込む

### DIFF
--- a/build/block.json
+++ b/build/block.json
@@ -17,6 +17,8 @@
   },
   "textdomain": "custom-card-link",
   "editorScript": "file:./index.js",
-  "editorStyle": "file:./index.css",
-  "style": "file:./style-index.css"
+  "editorStyle": [
+    "file:./index.css",
+    "file:./style-index.css"
+  ]
 }

--- a/functions/style.php
+++ b/functions/style.php
@@ -1,7 +1,10 @@
 <?php
 namespace Ccl_Plugin\functions\rest_api;
 
+use const Ccl_Plugin\CCL_SLUG;
 use function Ccl_Plugin\functions\data\get_setting;
+
+const FRONTEND_STYLE_HANDLE = 'custom-card-link-frontend';
 
 /**
  * 動的スタイルシート
@@ -9,7 +12,6 @@ use function Ccl_Plugin\functions\data\get_setting;
  */
 function dynamic_styles(){
 	$css  = '';
-	$css .= '<style type="text/css">';
 	if( get_setting('shadow_use') == 'shadow' ) {
 		$css .= '  .ccl {';
 		$css .= '    box-shadow: '.get_setting('shadow_offset_x').'px '.get_setting('shadow_offset_y').'px '
@@ -77,13 +79,41 @@ function dynamic_styles(){
 	$css .= '    margin-left: '.get_setting('gap_between_title_and_thumbnail_sp').'px;';
 	$css .= '  }';
 	$css .= '}';
-	$css .= '</style>';
 	return $css;
 }
 
 /**
- * ヘッダーにCSSを挿入
+ * フロントエンド用スタイルを登録
  */
-add_action('wp_head', function() {
-	echo dynamic_styles();
+add_action('init', function() {
+	$style_path = dirname(__DIR__).'/build/style-index.css';
+	$version    = file_exists($style_path) ? (string) filemtime($style_path) : null;
+
+	wp_register_style(
+		FRONTEND_STYLE_HANDLE,
+		plugin_dir_url(dirname(__DIR__).'/custom-card-link.php').'build/style-index.css',
+		array(),
+		$version
+	);
+
+	wp_style_add_data(FRONTEND_STYLE_HANDLE, 'rtl', 'replace');
+});
+
+/**
+ * ブロックが描画されたページでのみスタイルを読み込む
+ *
+ * @param string $block_content
+ * @return string
+ */
+add_filter('render_block_'.CCL_SLUG.'/'.CCL_SLUG, function($block_content) {
+	static $dynamic_styles_added = false;
+
+	wp_enqueue_style(FRONTEND_STYLE_HANDLE);
+
+	if(!$dynamic_styles_added) {
+		wp_add_inline_style(FRONTEND_STYLE_HANDLE, dynamic_styles());
+		$dynamic_styles_added = true;
+	}
+
+	return $block_content;
 });

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tested up to:      7.0
 Stable tag:        1.0.3
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Requires at least: 6.0
+Requires at least: 6.9
 Requires PHP:      8.0
 
 You can create flexible and customizable card-style external links.

--- a/src/block.json
+++ b/src/block.json
@@ -17,6 +17,8 @@
 	},
 	"textdomain": "custom-card-link",
 	"editorScript": "file:./index.js",
-	"editorStyle": "file:./index.css",
-	"style": "file:./style-index.css"
+	"editorStyle": [
+		"file:./index.css",
+		"file:./style-index.css"
+	]
 }


### PR DESCRIPTION
[via Codex]

## 概要

Custom Card Linkブロックが実際に描画されたページでのみ、フロントエンド用CSSを読み込むように変更しました。

- `block.json`からフロントエンドCSSの常時読み込み指定を削除
- エディターでは従来どおりカード用CSSを読み込むよう`editorStyle`を維持
- フロントエンドCSSを登録だけ行い、対象ブロックの`render_block`時にenqueue
- 動的CSSも同じスタイルハンドルへ一度だけ追加
- RTL用CSSの置き換えを維持

## 背景

これまではCustom Card Linkブロックがないページでも、`style-index.css`と設定値から生成した動的CSSが読み込まれていました。

今回の変更により、カードがないページではプラグインのフロントエンドCSSを出力せず、カードがあるページだけで必要なCSSを読み込みます。

## 確認内容

- カード0件の固定ページで静的CSS・動的CSSが出力されないこと
- カード0件の検索結果で静的CSS・動的CSSが出力されないこと
- カード36件のページで静的CSS・動的CSSがそれぞれ1回だけ出力されること
- ブロックエディター用の2つのスタイルハンドルが登録されること
- LighthouseでプラグインCSSのリクエストが1件、コンソールエラーが0件であること
- 表示崩れがないこと

## 検証

- `yarn build`
- `yarn lint`
- `composer check:php`

Closes #9