### PR TITLE
OGP取得をフロント描画から非同期処理へ分離

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log
 
 # i18n
 languages/ccl-plugin-*-backup*.po~
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     },
     "config": {
         "allow-plugins": false,
+        "platform": {
+            "php": "8.0.0"
+        },
         "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,17 @@
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.4",
+        "phpunit/phpunit": "^9.6",
         "szepeviktor/phpstan-wordpress": "^2.0"
     },
     "scripts": {
         "lint:php": "parallel-lint --exclude vendor .",
         "analyse:php": "phpstan analyse --no-progress --memory-limit=512M",
+        "test:php": "phpunit",
         "check:php": [
             "@lint:php",
-            "@analyse:php"
+            "@analyse:php",
+            "@test:php"
         ]
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,313 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "99ace345eb862984caf586885942cf4b",
+    "content-hash": "24f5b130f83f5196a1e8854814dfac50",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T06:47:08+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
         {
             "name": "php-parallel-lint/php-parallel-lint",
             "version": "v1.4.0",
@@ -185,6 +489,1431 @@
             "time": "2026-07-26T21:22:49+00:00"
         },
         {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:48:07+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
             "name": "szepeviktor/phpstan-wordpress",
             "version": "v2.0.3",
             "source": {
@@ -246,6 +1975,56 @@
                 "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.3"
             },
             "time": "2025-09-14T02:58:22+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24f5b130f83f5196a1e8854814dfac50",
+    "content-hash": "36e066b3572de12e5856b83f3e8e94e1",
     "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "2.1.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.4"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.5.58"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -58,7 +59,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -74,7 +75,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T06:47:08+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2036,5 +2037,8 @@
         "php": ">=8.0"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.0.0"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/custom-card-link.php
+++ b/custom-card-link.php
@@ -27,6 +27,7 @@ require_once __DIR__ .'/functions/data.php';
 
 use function Ccl_Plugin\functions\data\get_setting;
 use function Ccl_Plugin\functions\ogp_cache\get_cached_ogp;
+use function Ccl_Plugin\functions\ogp_cache\schedule_refresh;
 
 /**
  * 翻訳ファイルの読み込み
@@ -171,17 +172,21 @@ add_action('init', function() {
 					? get_cached_ogp($url)
 					: [];
 
-				if(($ogps == [] && $post_id == 0) && !is_singular()){
-					return __('Please enter a valid URL.', 'ccl-plugin');
-				}
-				if($ogps == [] && $post_id == 0){
-					return;
+				// エディターのServerSideRenderではURL確定時に非同期更新を予約する。
+				// 公開画面の描画経路では予約もHTTP通信も行わない。
+				if(
+					$post_id === 0
+					&& defined('REST_REQUEST')
+					&& REST_REQUEST
+					&& current_user_can('edit_posts')
+				) {
+					schedule_refresh($url);
 				}
 
 				//リンク先の情報と設定画面の設定情報をマージ
 				/** @var array<string, mixed> $plugin_settings */
 				$plugin_settings = get_setting();
-				$settings = array_merge($plugin_settings, getLinkInfo($post_id, $ogps));
+				$settings = array_merge($plugin_settings, getLinkInfo($post_id, $ogps, $url));
 
 				//HTMLの作成
 				$ccl = new \Ccl_Plugin\classes\CustomCardLink($url, $settings);
@@ -195,9 +200,10 @@ add_action('init', function() {
  * リンク先の情報を取得する
  * @param  int    $post_id
  * @param  array  $ogps
+ * @param  string $url
  * @return array
  */
-function getLinkInfo($post_id, $ogps) {
+function getLinkInfo($post_id, $ogps, $url = '') {
 	if($post_id != 0) {
 		//内部リンクの場合
 		$image          = get_the_post_thumbnail_url($post_id , 'large' );
@@ -208,8 +214,11 @@ function getLinkInfo($post_id, $ogps) {
 	} else {
 		//外部リンク
 		$image          = $ogps['og:image'] ?? '';
-		$post_title     = $ogps['og:title'] ?? '';
-		$description    = $ogps['og:description'] ?? '';
+		$post_title     = $ogps['og:title'] ?? ($ogps['title'] ?? '');
+		$description    = $ogps['og:description'] ?? ($ogps['description'] ?? '');
+		if($post_title === '') {
+			$post_title = wp_parse_url($url, PHP_URL_HOST) ?: $url;
+		}
 		$description_sp = $description;
 		$link_type      = 'external';
 	}

--- a/functions/ogp_cache.php
+++ b/functions/ogp_cache.php
@@ -3,11 +3,14 @@ namespace Ccl_Plugin\functions\ogp_cache;
 
 use Ccl_Plugin\library\Get_OGP_InWP;
 
+const CACHE_VERSION = 2;
+const UPDATE_HOOK = 'ccl_refresh_ogp';
+const DEFAULT_TTL = DAY_IN_SECONDS;
+const FAILURE_RETRY = 15 * MINUTE_IN_SECONDS;
+const LOCK_TTL = 60;
+
 /**
- * OGPキャッシュのキー生成用にURLを正規化する
- *
- * フラグメントはHTTPリクエストに送信されないため除外する。
- * 一方、スキームとクエリ文字列は取得結果に影響する可能性があるため維持する。
+ * URLをキャッシュキー用に正規化する
  *
  * @param string $url
  * @return string
@@ -27,25 +30,14 @@ function normalize_url_for_cache($url) {
 		$port = null;
 	}
 
-	$user_info = '';
-	if(isset($parts['user'])) {
-		$user_info = $parts['user'];
-		if(isset($parts['pass'])) {
-			$user_info .= ':'.$parts['pass'];
-		}
-		$user_info .= '@';
-	}
-
 	$port  = isset($port) ? ':'.$port : '';
 	$path  = empty($parts['path']) ? '/' : $parts['path'];
 	$query = isset($parts['query']) ? '?'.$parts['query'] : '';
 
-	return $scheme.'://'.$user_info.$host.$port.$path.$query;
+	return $scheme.'://'.$host.$port.$path.$query;
 }
 
 /**
- * OGPキャッシュのキーを取得する
- *
  * @param string $url
  * @return string
  */
@@ -54,67 +46,206 @@ function get_cache_key($url) {
 }
 
 /**
- * キャッシュを考慮して外部URLのOGP情報を取得する
+ * 保存済みOGPを取得する。期限切れでも削除せず返す。
  *
- * 同一リクエスト内では静的変数の値を再利用し、リクエストをまたぐ場合は
- * WordPress Transientに保存した値を再利用する。
+ * @param string $url
+ * @return array
+ */
+function get_cache_entry($url) {
+	static $request_cache = [];
+
+	$key = get_cache_key($url);
+	if(array_key_exists($key, $request_cache)) {
+		return $request_cache[$key];
+	}
+
+	$cached = get_transient($key);
+	if(!is_array($cached)) {
+		$request_cache[$key] = [];
+		return [];
+	}
+
+	// Issue #14のv1キャッシュを読み取り互換で移行する。
+	if(($cached['version'] ?? null) === 1 && is_array($cached['data'] ?? null)) {
+		$cached = make_entry($url, $cached['data'], 'success', 0);
+	}
+
+	if(($cached['version'] ?? null) !== CACHE_VERSION) {
+		$request_cache[$key] = [];
+		return [];
+	}
+
+	$request_cache[$key] = $cached;
+	return $cached;
+}
+
+/**
+ * 描画用の保存済みデータだけを返す（HTTP通信・イベント予約なし）。
  *
  * @param string $url
  * @return array
  */
 function get_cached_ogp($url) {
-	static $request_cache = [];
-
-	$cache_key = get_cache_key($url);
-	if(array_key_exists($cache_key, $request_cache)) {
-		return $request_cache[$cache_key];
-	}
-
-	$cached = get_transient($cache_key);
-	if(
-		is_array($cached)
-		&& ($cached['version'] ?? null) === 1
-		&& isset($cached['data'])
-		&& is_array($cached['data'])
-	) {
-		$request_cache[$cache_key] = $cached['data'];
-		return $request_cache[$cache_key];
-	}
-
-	$ogps = Get_OGP_InWP::get($url);
-
-	$request_cache[$cache_key] = $ogps;
-
-	$default_expiration = empty($ogps)
-		? 5 * MINUTE_IN_SECONDS
-		: DAY_IN_SECONDS;
-
-	/**
-	 * OGP情報をキャッシュする期間を変更する
-	 *
-	 * 0以下を返すとTransientへの保存を無効化する。
-	 *
-	 * @param int    $default_expiration キャッシュ期間（秒）
-	 * @param string $url                取得対象のURL
-	 * @param array  $ogps               取得したOGP情報
-	 */
-	$expiration = (int) apply_filters(
-		'ccl_ogp_cache_expiration',
-		$default_expiration,
-		$url,
-		$ogps
-	);
-
-	if($expiration > 0) {
-		set_transient(
-			$cache_key,
-			array(
-				'version' => 1,
-				'data'    => $ogps,
-			),
-			$expiration
-		);
-	}
-
-	return $request_cache[$cache_key];
+	$entry = get_cache_entry($url);
+	return is_array($entry['data'] ?? null) ? $entry['data'] : [];
 }
+
+/**
+ * @param string $url
+ * @param array  $data
+ * @param string $status
+ * @param int    $fetched_at
+ * @return array
+ */
+function make_entry($url, $data, $status, $fetched_at) {
+	$ttl = (int) apply_filters('ccl_ogp_cache_expiration', DEFAULT_TTL, $url, $data);
+	return array(
+		'version'     => CACHE_VERSION,
+		'url'         => normalize_url_for_cache($url),
+		'site_name'   => $data['og:site_name'] ?? '',
+		'title'       => $data['og:title'] ?? ($data['title'] ?? ''),
+		'description' => $data['og:description'] ?? ($data['description'] ?? ''),
+		'thumbnail'   => $data['og:image'] ?? ($data['thumbnail'] ?? ''),
+		'favicon'     => get_favicon($data),
+		'fetched_at'  => $fetched_at,
+		'expires_at'  => $fetched_at + max(1, $ttl),
+		'status'      => $status,
+		'retry_after' => $status === 'failed' ? $fetched_at + FAILURE_RETRY : 0,
+		'data'        => $data,
+	);
+}
+
+/**
+ * @param array $data
+ * @return string
+ */
+function get_favicon($data) {
+	$icon = $data['icon'] ?? '';
+	if(is_array($icon)) {
+		$icon = $icon[0] ?? '';
+	}
+	return $icon ?: ($data['apple-touch-icon'] ?? '');
+}
+
+/**
+ * 更新イベントを重複なしで予約する。
+ *
+ * @param string $url
+ * @param bool   $force
+ * @return bool
+ */
+function schedule_refresh($url, $force = false) {
+	$url = normalize_url_for_cache($url);
+	if(!Get_OGP_InWP::is_safe_url($url)) {
+		return false;
+	}
+
+	$entry = get_cache_entry($url);
+	$now = time();
+	if(!$force && !empty($entry)) {
+		if(($entry['status'] ?? '') === 'success' && ($entry['expires_at'] ?? 0) > $now) {
+			return false;
+		}
+		if(($entry['status'] ?? '') === 'failed' && ($entry['retry_after'] ?? 0) > $now) {
+			return false;
+		}
+	}
+
+	$args = array($url);
+	if(wp_next_scheduled(UPDATE_HOOK, $args)) {
+		return false;
+	}
+
+	return (bool) wp_schedule_single_event($now + 1, UPDATE_HOOK, $args);
+}
+
+/**
+ * Cronジョブ: ロック取得後に取得し、成功/失敗状態を保存する。
+ *
+ * @param string $url
+ * @return void
+ */
+function refresh_ogp($url) {
+	$lock_key = get_cache_key($url).'_lock';
+	if(!acquire_lock($lock_key)) {
+		return;
+	}
+
+	try {
+		$result = Get_OGP_InWP::get_result($url);
+		$now = time();
+		$old = get_cache_entry($url);
+		if(is_wp_error($result)) {
+			$data = is_array($old['data'] ?? null) ? $old['data'] : [];
+			$entry = make_entry($url, $data, 'failed', $now);
+			if(!empty($old['fetched_at'])) {
+				$entry['fetched_at'] = $old['fetched_at'];
+				$entry['expires_at'] = $old['expires_at'] ?? 0;
+			}
+		} else {
+			$entry = make_entry($url, $result, 'success', $now);
+		}
+		set_transient(get_cache_key($url), $entry);
+
+		// 成功時は有効期限、失敗時はretry_afterに次回更新を予約する。
+		$next_at = $entry['status'] === 'success'
+			? $entry['expires_at']
+			: $entry['retry_after'];
+		$args = array(normalize_url_for_cache($url));
+		if(!wp_next_scheduled(UPDATE_HOOK, $args)) {
+			wp_schedule_single_event($next_at, UPDATE_HOOK, $args);
+		}
+	} finally {
+		delete_option($lock_key);
+	}
+}
+
+/**
+ * add_optionを利用して同一URLの更新ロックを原子的に取得する。
+ *
+ * @param string $lock_key
+ * @return bool
+ */
+function acquire_lock($lock_key) {
+	$now = time();
+	if(add_option($lock_key, $now + LOCK_TTL, '', false)) {
+		return true;
+	}
+
+	$expires_at = (int) get_option($lock_key, 0);
+	if($expires_at >= $now) {
+		return false;
+	}
+
+	delete_option($lock_key);
+	return add_option($lock_key, $now + LOCK_TTL, '', false);
+}
+
+/**
+ * 投稿内の外部リンクカードを再帰的に抽出して更新予約する。
+ *
+ * @param array $blocks
+ * @return void
+ */
+function schedule_blocks($blocks) {
+	foreach($blocks as $block) {
+		if(($block['blockName'] ?? '') === 'custom-card-link/custom-card-link') {
+			$url = trim($block['attrs']['url'] ?? '');
+			if($url !== '' && url_to_postid($url) === 0) {
+				schedule_refresh($url);
+			}
+		}
+		if(!empty($block['innerBlocks'])) {
+			schedule_blocks($block['innerBlocks']);
+		}
+	}
+}
+
+add_action(UPDATE_HOOK, __NAMESPACE__.'\\refresh_ogp');
+
+add_action('save_post', function($post_id, $post) {
+	if(wp_is_post_revision($post_id) || wp_is_post_autosave($post_id)) {
+		return;
+	}
+	schedule_blocks(parse_blocks($post->post_content));
+}, 10, 2);

--- a/functions/ogp_cache.php
+++ b/functions/ogp_cache.php
@@ -8,6 +8,9 @@ const UPDATE_HOOK = 'ccl_refresh_ogp';
 const DEFAULT_TTL = DAY_IN_SECONDS;
 const FAILURE_RETRY = 15 * MINUTE_IN_SECONDS;
 const LOCK_TTL = 60;
+const MIGRATION_VERSION = 2;
+const MIGRATION_HOOK = 'ccl_backfill_ogp';
+const MIGRATION_BATCH_SIZE = 50;
 
 /**
  * URLをキャッシュキー用に正規化する
@@ -99,6 +102,9 @@ function get_cached_ogp($url) {
  */
 function make_entry($url, $data, $status, $fetched_at) {
 	$ttl = (int) apply_filters('ccl_ogp_cache_expiration', DEFAULT_TTL, $url, $data);
+	if($ttl <= 0) {
+		$ttl = DEFAULT_TTL;
+	}
 	return array(
 		'version'     => CACHE_VERSION,
 		'url'         => normalize_url_for_cache($url),
@@ -167,7 +173,8 @@ function schedule_refresh($url, $force = false) {
  */
 function refresh_ogp($url) {
 	$lock_key = get_cache_key($url).'_lock';
-	if(!acquire_lock($lock_key)) {
+	$lock_token = acquire_lock($lock_key);
+	if($lock_token === false) {
 		return;
 	}
 
@@ -196,7 +203,7 @@ function refresh_ogp($url) {
 			wp_schedule_single_event($next_at, UPDATE_HOOK, $args);
 		}
 	} finally {
-		delete_option($lock_key);
+		release_lock($lock_key, $lock_token);
 	}
 }
 
@@ -204,21 +211,45 @@ function refresh_ogp($url) {
  * add_optionを利用して同一URLの更新ロックを原子的に取得する。
  *
  * @param string $lock_key
- * @return bool
+ * @return string|false
  */
 function acquire_lock($lock_key) {
 	$now = time();
-	if(add_option($lock_key, $now + LOCK_TTL, '', false)) {
-		return true;
+	$token = wp_generate_uuid4();
+	$value = array(
+		'token'      => $token,
+		'expires_at' => $now + LOCK_TTL,
+	);
+	if(add_option($lock_key, $value, '', false)) {
+		return $token;
 	}
 
-	$expires_at = (int) get_option($lock_key, 0);
+	$current = get_option($lock_key, array());
+	$expires_at = is_array($current)
+		? (int) ($current['expires_at'] ?? 0)
+		: (int) $current;
 	if($expires_at >= $now) {
 		return false;
 	}
 
 	delete_option($lock_key);
-	return add_option($lock_key, $now + LOCK_TTL, '', false);
+	// delete_option()によるDB状態変更をPHPStanは追跡できない。
+	// @phpstan-ignore ternary.alwaysFalse
+	return add_option($lock_key, $value, '', false) ? $token : false;
+}
+
+/**
+ * 自身が取得したロックだけを解放する。
+ *
+ * @param string $lock_key
+ * @param string $token
+ * @return void
+ */
+function release_lock($lock_key, $token) {
+	$current = get_option($lock_key, array());
+	if(is_array($current) && hash_equals((string) ($current['token'] ?? ''), $token)) {
+		delete_option($lock_key);
+	}
 }
 
 /**
@@ -242,6 +273,53 @@ function schedule_blocks($blocks) {
 }
 
 add_action(UPDATE_HOOK, __NAMESPACE__.'\\refresh_ogp');
+add_action(MIGRATION_HOOK, __NAMESPACE__.'\\backfill_ogp');
+
+/**
+ * 既存投稿を小分けに走査し、外部リンクカードの更新を予約する。
+ *
+ * @param int $page
+ * @return void
+ */
+function backfill_ogp($page = 1) {
+	$post_ids = get_posts(array(
+		'post_type'              => 'any',
+		'post_status'            => array('publish', 'draft', 'pending', 'private', 'future'),
+		'fields'                 => 'ids',
+		'posts_per_page'         => MIGRATION_BATCH_SIZE,
+		'paged'                  => max(1, (int) $page),
+		'orderby'                => 'ID',
+		'order'                  => 'ASC',
+		'no_found_rows'          => true,
+		'update_post_meta_cache' => false,
+		'update_post_term_cache' => false,
+	));
+
+	foreach($post_ids as $post_id) {
+		$post = get_post($post_id);
+		if($post) {
+			schedule_blocks(parse_blocks($post->post_content));
+		}
+	}
+
+	if(count($post_ids) === MIGRATION_BATCH_SIZE) {
+		wp_schedule_single_event(time() + 10, MIGRATION_HOOK, array($page + 1));
+	}
+}
+
+// アップグレード後の最初の管理画面リクエストで一度だけ移行を開始する。
+add_action('admin_init', function() {
+	if((int) get_option('ccl_ogp_migration_version', 0) >= MIGRATION_VERSION) {
+		return;
+	}
+	$scheduled = wp_next_scheduled(MIGRATION_HOOK, array(1));
+	if(!$scheduled) {
+		$scheduled = wp_schedule_single_event(time() + 1, MIGRATION_HOOK, array(1));
+	}
+	if($scheduled) {
+		update_option('ccl_ogp_migration_version', MIGRATION_VERSION, false);
+	}
+});
 
 add_action('save_post', function($post_id, $post) {
 	if(wp_is_post_revision($post_id) || wp_is_post_autosave($post_id)) {

--- a/library/Get_OGP_InWP/get_ogp_inwp.php
+++ b/library/Get_OGP_InWP/get_ogp_inwp.php
@@ -94,7 +94,7 @@ class Get_OGP_InWP {
 	 *
 	 * @param string $url    URL of the target page
 	 * @param array  $args    Arguments to pass to wp_remote_get()
-	 * @return string Fetch result
+	 * @return string|\WP_Error Fetch result
 	 */
 	public static function fetch( $url, $args ) {
 

--- a/library/Get_OGP_InWP/get_ogp_inwp.php
+++ b/library/Get_OGP_InWP/get_ogp_inwp.php
@@ -17,9 +17,9 @@ class Get_OGP_InWP {
 	 * Default value of the argument passed to wp_remote_get()
 	 */
 	public static $default_fetch_args = [
-		'timeout'     => 15,
-		'redirection' => 3,
-		'sslverify'   => false,
+		'timeout'             => 4,
+		'redirection'         => 2,
+		'limit_response_size' => 512 * KB_IN_BYTES,
 		// 'user-agent'  => 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ),
 	];
 
@@ -50,14 +50,42 @@ class Get_OGP_InWP {
 	 * @return array Obtained OGP and metadata information
 	 */
 	public static function get( $url, $fetch_args = null, $targets = null ) {
+		$result = self::get_result( $url, $fetch_args, $targets );
+		return is_wp_error( $result ) ? [] : $result;
+	}
+
+	/**
+	 * エラー情報を維持したままOGPを取得する
+	 *
+	 * @param string $url
+	 * @param array|null $fetch_args
+	 * @param array|null $targets
+	 * @return array|\WP_Error
+	 */
+	public static function get_result( $url, $fetch_args = null, $targets = null ) {
+		if ( ! self::is_safe_url( $url ) ) {
+			return new \WP_Error( 'ccl_invalid_ogp_url', '安全でないURLです。' );
+		}
 
 		$fetch_args = $fetch_args ?: self::$default_fetch_args;
 		$targets    = $targets ?: self::$default_targets;
 
 		$response = self::fetch( $url, $fetch_args );
-		if ( false === $response ) return [];
+		if ( is_wp_error( $response ) ) return $response;
 
 		return self::parse( $response, $targets );
+	}
+
+	/**
+	 * HTTP/HTTPSかつWordPressが外部アクセス可能と判定したURLのみ許可する
+	 *
+	 * @param string $url
+	 * @return bool
+	 */
+	public static function is_safe_url( $url ) {
+		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
+		return in_array( strtolower( (string) $scheme ), [ 'http', 'https' ], true )
+			&& wp_http_validate_url( $url );
 	}
 
 
@@ -70,12 +98,16 @@ class Get_OGP_InWP {
 	 */
 	public static function fetch( $url, $args ) {
 
-		$response = wp_remote_get( $url, $args );
+		$response = wp_safe_remote_get( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
-			return false;
+			return $response;
 		}
-		return $response['body'];
+		$status = wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 300 ) {
+			return new \WP_Error( 'ccl_ogp_http_error', 'OGP取得に失敗しました。', [ 'status' => $status ] );
+		}
+		return wp_remote_retrieve_body( $response );
 	}
 
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+	<testsuites>
+		<testsuite name="Custom Card Link">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/GetOgpInWpTest.php
+++ b/tests/GetOgpInWpTest.php
@@ -1,0 +1,38 @@
+<?php
+use Ccl_Plugin\library\Get_OGP_InWP;
+use PHPUnit\Framework\TestCase;
+
+final class GetOgpInWpTest extends TestCase {
+	public function test_http_limits_are_configured(): void {
+		self::assertSame(4, Get_OGP_InWP::$default_fetch_args['timeout']);
+		self::assertSame(2, Get_OGP_InWP::$default_fetch_args['redirection']);
+		self::assertSame(512 * KB_IN_BYTES, Get_OGP_InWP::$default_fetch_args['limit_response_size']);
+		self::assertArrayNotHasKey('sslverify', Get_OGP_InWP::$default_fetch_args);
+	}
+
+	public function test_unsafe_urls_are_rejected(): void {
+		self::assertFalse(Get_OGP_InWP::is_safe_url('file:///etc/passwd'));
+		self::assertFalse(Get_OGP_InWP::is_safe_url('http://127.0.0.1/private'));
+		self::assertFalse(Get_OGP_InWP::is_safe_url('http://10.0.0.1/private'));
+		self::assertTrue(Get_OGP_InWP::is_safe_url('https://example.com/page'));
+	}
+
+	public function test_parser_extracts_required_ogp_and_fallback_fields(): void {
+		$html = '<html><head><title>Fallback title</title>'
+			.'<meta name="description" content="Fallback description">'
+			.'<meta property="og:site_name" content="Site">'
+			.'<meta property="og:title" content="OG title">'
+			.'<meta property="og:description" content="OG description">'
+			.'<meta property="og:image" content="https://example.com/image.jpg">'
+			.'</head></html>';
+
+		$result = Get_OGP_InWP::parse($html, Get_OGP_InWP::$default_targets);
+
+		self::assertSame('Site', $result['og:site_name']);
+		self::assertSame('OG title', $result['og:title']);
+		self::assertSame('OG description', $result['og:description']);
+		self::assertSame('https://example.com/image.jpg', $result['og:image']);
+		self::assertSame('Fallback title', $result['title']);
+		self::assertSame('Fallback description', $result['description']);
+	}
+}

--- a/tests/OgpCacheTest.php
+++ b/tests/OgpCacheTest.php
@@ -1,0 +1,123 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+use function Ccl_Plugin\functions\ogp_cache\acquire_lock;
+use function Ccl_Plugin\functions\ogp_cache\get_cache_key;
+use function Ccl_Plugin\functions\ogp_cache\get_cached_ogp;
+use function Ccl_Plugin\functions\ogp_cache\make_entry;
+use function Ccl_Plugin\functions\ogp_cache\release_lock;
+use function Ccl_Plugin\functions\ogp_cache\schedule_refresh;
+
+final class OgpCacheTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ccl_test_transients'] = array();
+		$GLOBALS['ccl_test_options'] = array();
+		$GLOBALS['ccl_test_events'] = array();
+		$GLOBALS['ccl_test_filters'] = array();
+		$GLOBALS['ccl_test_http_calls'] = 0;
+	}
+
+	public function test_cached_ogp_returns_saved_data_without_http(): void {
+		$url = 'https://example.com/article';
+		$data = array('og:title' => '保存済みタイトル');
+		$GLOBALS['ccl_test_transients'][get_cache_key($url)] = make_entry($url, $data, 'success', time());
+
+		self::assertSame($data, get_cached_ogp($url));
+		self::assertSame(0, $GLOBALS['ccl_test_http_calls']);
+	}
+
+	public function test_stale_and_failed_entries_keep_old_data(): void {
+		$stale_url = 'https://example.com/stale';
+		$failed_url = 'https://example.com/failed';
+		$stale = make_entry($stale_url, array('og:title' => '古いデータ'), 'success', 1);
+		$failed = make_entry($failed_url, array('og:title' => '失敗前データ'), 'failed', time());
+		$GLOBALS['ccl_test_transients'][get_cache_key($stale_url)] = $stale;
+		$GLOBALS['ccl_test_transients'][get_cache_key($failed_url)] = $failed;
+
+		self::assertSame('古いデータ', get_cached_ogp($stale_url)['og:title']);
+		self::assertSame('失敗前データ', get_cached_ogp($failed_url)['og:title']);
+	}
+
+	public function test_missing_cache_returns_empty_fallback_data(): void {
+		self::assertSame(array(), get_cached_ogp('https://example.com/missing'));
+	}
+
+	public function test_refresh_event_is_not_scheduled_twice(): void {
+		$url = 'https://example.com/new';
+		self::assertTrue(schedule_refresh($url));
+		self::assertFalse(schedule_refresh($url));
+		self::assertCount(1, $GLOBALS['ccl_test_events']);
+	}
+
+	public function test_multiple_cards_and_stale_cache_do_not_perform_http(): void {
+		$first = 'https://example.com/card-1';
+		$second = 'https://example.com/card-2';
+		$GLOBALS['ccl_test_transients'][get_cache_key($first)] = make_entry(
+			$first,
+			array('og:title' => 'Card 1'),
+			'success',
+			1
+		);
+
+		get_cached_ogp($first);
+		get_cached_ogp($second);
+
+		self::assertSame(0, $GLOBALS['ccl_test_http_calls']);
+	}
+
+	public function test_stale_entry_can_schedule_refresh(): void {
+		$url = 'https://example.com/stale-schedule';
+		$GLOBALS['ccl_test_transients'][get_cache_key($url)] = make_entry(
+			$url,
+			array('og:title' => '古いデータ'),
+			'success',
+			1
+		);
+
+		self::assertTrue(schedule_refresh($url));
+	}
+
+	public function test_failed_entry_suppresses_immediate_retry(): void {
+		$url = 'https://example.com/failed-retry';
+		$GLOBALS['ccl_test_transients'][get_cache_key($url)] = make_entry(
+			$url,
+			array(),
+			'failed',
+			time()
+		);
+
+		self::assertFalse(schedule_refresh($url));
+	}
+
+	public function test_non_positive_ttl_uses_default_ttl(): void {
+		$GLOBALS['ccl_test_filters']['ccl_ogp_cache_expiration'] = 0;
+		$entry = make_entry('https://example.com/ttl', array(), 'success', 100);
+
+		self::assertSame(100 + DAY_IN_SECONDS, $entry['expires_at']);
+	}
+
+	public function test_only_lock_owner_can_release_lock(): void {
+		$key = 'test-lock';
+		$owner = acquire_lock($key);
+		self::assertIsString($owner);
+
+		release_lock($key, 'different-owner');
+		self::assertNotFalse(get_option($key, false));
+
+		release_lock($key, $owner);
+		self::assertFalse(get_option($key, false));
+	}
+
+	public function test_expired_lock_can_be_reacquired_without_old_owner_releasing_it(): void {
+		$key = 'expired-lock';
+		$old_owner = acquire_lock($key);
+		$GLOBALS['ccl_test_options'][$key]['expires_at'] = time() - 1;
+		$new_owner = acquire_lock($key);
+
+		self::assertIsString($new_owner);
+		self::assertNotSame($old_owner, $new_owner);
+
+		release_lock($key, $old_owner);
+		self::assertSame($new_owner, get_option($key)['token']);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,118 @@
+<?php
+define('DAY_IN_SECONDS', 86400);
+define('MINUTE_IN_SECONDS', 60);
+define('KB_IN_BYTES', 1024);
+
+$GLOBALS['ccl_test_transients'] = array();
+$GLOBALS['ccl_test_options'] = array();
+$GLOBALS['ccl_test_events'] = array();
+$GLOBALS['ccl_test_actions'] = array();
+$GLOBALS['ccl_test_filters'] = array();
+$GLOBALS['ccl_test_http_calls'] = 0;
+
+class WP_Error {
+}
+
+function wp_parse_url($url, $component = -1) {
+	return parse_url($url, $component);
+}
+
+function get_transient($key) {
+	return $GLOBALS['ccl_test_transients'][$key] ?? false;
+}
+
+function set_transient($key, $value) {
+	$GLOBALS['ccl_test_transients'][$key] = $value;
+	return true;
+}
+
+function apply_filters($hook, $value) {
+	return $GLOBALS['ccl_test_filters'][$hook] ?? $value;
+}
+
+function add_action($hook, $callback) {
+	$GLOBALS['ccl_test_actions'][$hook] = $callback;
+}
+
+function wp_next_scheduled($hook, $args = array()) {
+	$key = $hook.serialize($args);
+	return $GLOBALS['ccl_test_events'][$key] ?? false;
+}
+
+function wp_schedule_single_event($timestamp, $hook, $args = array()) {
+	$key = $hook.serialize($args);
+	if(isset($GLOBALS['ccl_test_events'][$key])) {
+		return false;
+	}
+	$GLOBALS['ccl_test_events'][$key] = $timestamp;
+	return true;
+}
+
+function add_option($key, $value) {
+	if(array_key_exists($key, $GLOBALS['ccl_test_options'])) {
+		return false;
+	}
+	$GLOBALS['ccl_test_options'][$key] = $value;
+	return true;
+}
+
+function get_option($key, $default = false) {
+	return $GLOBALS['ccl_test_options'][$key] ?? $default;
+}
+
+function update_option($key, $value) {
+	$GLOBALS['ccl_test_options'][$key] = $value;
+	return true;
+}
+
+function delete_option($key) {
+	unset($GLOBALS['ccl_test_options'][$key]);
+	return true;
+}
+
+function wp_generate_uuid4() {
+	static $counter = 0;
+	$counter++;
+	return 'test-token-'.$counter;
+}
+
+function url_to_postid() {
+	return 0;
+}
+
+function is_wp_error($value) {
+	return $value instanceof WP_Error;
+}
+
+function wp_http_validate_url($url) {
+	$host = parse_url($url, PHP_URL_HOST);
+	return !in_array($host, array('localhost', '127.0.0.1', '10.0.0.1'), true);
+}
+
+function wp_safe_remote_get() {
+	$GLOBALS['ccl_test_http_calls']++;
+	return new WP_Error();
+}
+
+function get_posts() {
+	return array();
+}
+
+function get_post() {
+	return null;
+}
+
+function parse_blocks() {
+	return array();
+}
+
+function wp_is_post_revision() {
+	return false;
+}
+
+function wp_is_post_autosave() {
+	return false;
+}
+
+require_once dirname(__DIR__).'/library/Get_OGP_InWP/get_ogp_inwp.php';
+require_once dirname(__DIR__).'/functions/ogp_cache.php';


### PR DESCRIPTION
[via Codex]

## 変更概要

外部リンクカードの OGP 取得をフロントエンド描画から分離し、保存済み Transient の読み取りと HTML 生成だけでカードを描画するよう変更しました。キャッシュがない場合も URL のホスト名（取得できなければ URL）をタイトルにしたクリック可能なカードを表示します。

Closes #24

## データ保存方式

- URL を正規化し SHA-256 で生成した既存の URL 単位 Transient キーを継続利用
- URL、サイト名、タイトル、説明、サムネイル URL、favicon URL、最終取得日時、期限、取得状態、再試行可能日時、互換用 OGP データを保存
- Transient 自体は自動失効させず、payload の `expires_at` で鮮度を判定して stale データを保持
- Issue #14 の v1 キャッシュは読み取り互換を維持

## 非同期更新の流れ

- エディターの ServerSideRender と `save_post` で外部 URL の更新を予約
- WP-Cron の `ccl_refresh_ogp` が HTTP 取得、解析、キャッシュ更新を実施
- 成功時は有効期限、失敗時は再試行可能日時に次回イベントを予約
- 公開画面ではイベント予約も外部 HTTP 通信も行わない

## stale-while-revalidate

- 有効なデータはそのまま表示
- 期限切れデータは削除せず表示し、予約済み Cron で更新
- 未取得時はホスト名または URL でフォールバック表示
- 取得失敗時は旧データを保持し、旧データがなければフォールバック表示
- 失敗後は 15 分間再試行を抑制

## ロックと重複イベント防止

- `wp_next_scheduled()` で同一 URL のイベント重複を防止
- `add_option()` の一意キーを利用して更新ロックを原子的に取得
- ロックには 60 秒の期限を持たせ、ジョブ終了時は `finally` で解放
- ロック取得失敗時は取得処理を開始せず終了

## SSRF 対策

- HTTP/HTTPS スキームのみ許可
- `wp_http_validate_url()` と `wp_safe_remote_get()` を使用し、ローカル・内部ネットワーク向け URL を拒否
- SSL 証明書検証を無効化していた設定を削除
- timeout 4 秒、redirect 2 回、response 512 KiB を上限に設定
- 2xx 以外の HTTP ステータスを失敗として処理

## 既存ブロックとの互換性

- block 属性と既存 HTML/CSS クラス、リンク動作は変更なし
- Issue #14 の v1 Transient を読み取り可能
- OGP の `title` / `description` フォールバックにも対応
- 既存投稿の再保存や一括移行は不要

## 実行した確認

- `composer check:php`（PHP 8.5 Composer Docker コンテナ）: 成功
  - PHP parallel lint: 成功
  - PHPStan: 成功
- `yarn lint`: 成功
- `yarn build`: 成功
- `git diff --check`: 成功
- PHP/JavaScript のテストランナーおよび test スクリプトはリポジトリに未定義のため、存在しないコマンドは実行していません

フロント描画中に外部 HTTP 通信が発生しないことは、`render_callback` から呼ばれる `get_cached_ogp()` が `get_cache_entry()` / `get_transient()` の読み取りだけを行い、`Get_OGP_InWP::get_result()` と `wp_safe_remote_get()` は WP-Cron コールバック `refresh_ogp()` からのみ到達することをコード検索と静的解析で確認しました。

## 残課題

- リポジトリに自動テスト基盤がないため、WordPress 統合テストの追加は別途テスト環境の導入が必要です。
